### PR TITLE
Update fonts to Geist and Geist_Mono for a more professional look

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Fonts
+
+This project uses the `Geist` and `Geist_Mono` fonts for a more professional look.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -17,7 +17,7 @@
 body {
   color: var(--foreground);
   background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-geist-sans), var(--font-geist-mono), Arial, Helvetica, sans-serif;
 }
 
 .service-card:hover {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,6 +12,10 @@ export default {
         background: "var(--background)",
         foreground: "var(--foreground)",
       },
+      fontFamily: {
+        geist: ["var(--font-geist-sans)", "Arial", "Helvetica", "sans-serif"],
+        geistMono: ["var(--font-geist-mono)", "Arial", "Helvetica", "sans-serif"],
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
Update the font settings to use `Geist` and `Geist_Mono` for a more professional look.

* **globals.css**
  - Change the `body` element to use `Geist` and `Geist_Mono` fonts.

* **tailwind.config.ts**
  - Add custom font settings for `Geist` and `Geist_Mono` in the `theme.extend` section.

* **README.md**
  - Add a section mentioning the use of `Geist` and `Geist_Mono` fonts for a more professional look.

